### PR TITLE
[FIX] 답변리스트 없어도 질문상세정보 조회가능

### DIFF
--- a/q-api/src/main/java/com/qcard/api/answer/service/AnswerService.java
+++ b/q-api/src/main/java/com/qcard/api/answer/service/AnswerService.java
@@ -7,8 +7,10 @@ import com.qcard.api.answer.dto.AnswerUpdateReq;
 import com.qcard.api.question.dto.QuestionDetailRes;
 import com.qcard.domains.account.entity.Account;
 import com.qcard.domains.heart.service.HeartDomainService;
+import com.qcard.domains.question.entity.Question;
 import com.qcard.domains.question.service.AnswerDomainService;
 import com.qcard.domains.question.entity.Answer;
+import com.qcard.domains.question.service.QuestionDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
@@ -23,6 +25,7 @@ import java.util.stream.Collectors;
 public class AnswerService {
     private final AnswerDomainService answerDomainService;
     private final HeartDomainService heartDomainService;
+    private final QuestionDomainService questionDomainService;
 
     public AnswerCreateRes createAnswer(Account account, AnswerReq answerReq) {
         Answer answer = answerDomainService.createAnswer(
@@ -35,10 +38,13 @@ public class AnswerService {
 
     public QuestionDetailRes findAnswerByQuestionId(Account account, Long questionId) {
         List<Answer> entities = answerDomainService.findAnswerByQuestionId(questionId);
+        if(entities.isEmpty()) {
+            Question question = questionDomainService.findQuestionById(questionId);
+            return new QuestionDetailRes(question, account);
+        }
 
         List<Long> answerIds = entities.stream().map(Answer::getId).toList();
         Map<Long, Integer> heartCounts = answerIds.stream().collect(Collectors.toMap(id -> id, heartDomainService::countHeartByAnswerId));
-
         List<Long> heartedAnswerList = heartDomainService.findHeartByAccount(account)
                 .stream().map(heart -> heart.getAnswer().getId()).toList();
 

--- a/q-api/src/main/java/com/qcard/api/question/dto/QuestionDetailRes.java
+++ b/q-api/src/main/java/com/qcard/api/question/dto/QuestionDetailRes.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.util.Pair;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -28,5 +29,11 @@ public class QuestionDetailRes {
         this.answers = answers.stream()
                 .map(answer -> new AnswerRes(answer, account, hearts, heartCnts.get(answer.getId())))
                 .collect(Collectors.toList());
+    }
+
+    public QuestionDetailRes(Question question, Account account) {
+        this.questionId = question.getId();
+        this.title = question.getTitle();
+        this.answers = new ArrayList<>();
     }
 }


### PR DESCRIPTION
- 답변이 없으면 질문상세정보 api 요청시 에러가 나오는 현상 해결