### PR TITLE
[FEAT] /question Detail Dto 반환 시 gpt 응답 추가

### DIFF
--- a/q-api/src/main/java/com/qcard/api/answer/dto/AnswerRes.java
+++ b/q-api/src/main/java/com/qcard/api/answer/dto/AnswerRes.java
@@ -49,6 +49,12 @@ public class AnswerRes {
         }
     }
 
+    public AnswerRes(Answer answer) {
+        this.answerId = answer.getId();
+        this.type = answer.getType();
+        this.content = answer.getContent();
+    }
+
     private AccountRes createdAccountRes(Account account) {
         return new AccountRes(account.getName(), account.getEmail());
     }

--- a/q-api/src/main/java/com/qcard/api/question/dto/QuestionDetailRes.java
+++ b/q-api/src/main/java/com/qcard/api/question/dto/QuestionDetailRes.java
@@ -1,6 +1,7 @@
 package com.qcard.api.question.dto;
 
 import com.qcard.api.answer.dto.AnswerRes;
+import com.qcard.common.enums.Type;
 import com.qcard.domains.account.entity.Account;
 import com.qcard.domains.heart.entity.Heart;
 import com.qcard.domains.question.entity.Answer;
@@ -19,11 +20,20 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestionDetailRes {
     private Question question;
+
+    private AnswerRes gpt;
     private List<AnswerRes> answers;
 
 
     public QuestionDetailRes(List<Answer> answers, Account account, List<Long> hearts, Map<Long, Integer> heartCnts) {
         this.question = answers.get(0).getQuestion();
+        for (Answer answer : answers) {
+            if (answer.getType() == Type.TYPE_GPT) {
+                this.gpt = new AnswerRes(answer);
+                answers.remove(answer);
+                break;
+            }
+        }
         this.answers = answers.stream()
                 .map(answer -> new AnswerRes(answer, account, hearts, heartCnts.get(answer.getId())))
                 .collect(Collectors.toList());

--- a/q-domain/src/main/java/com/qcard/domains/question/repository/AnswerRepository.java
+++ b/q-domain/src/main/java/com/qcard/domains/question/repository/AnswerRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
-    List<Answer> findAllByQuestionId(Long questionId);
+    List<Answer> findAllByQuestionIdOrderByTypeDesc(Long questionId);
 
     List<Answer> findAllByAccount(Account account);
 

--- a/q-domain/src/main/java/com/qcard/domains/question/service/AnswerDomainService.java
+++ b/q-domain/src/main/java/com/qcard/domains/question/service/AnswerDomainService.java
@@ -34,7 +34,7 @@ public class AnswerDomainService {
 
     @Transactional(readOnly = true)
     public List<Answer> findAnswerByQuestionId(Long questionId) {
-        return answerRepository.findAllByQuestionId(questionId);
+        return answerRepository.findAllByQuestionIdOrderByTypeDesc(questionId);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Details
1. Dto에서 gpt 응답을 더 확인하기 쉽도록 변경하였습니다.
```java
    private Question question;
    private AnswerRes gpt;
    private List<AnswerRes> answers;
```

2. 실행 시 변경된 json은 다음과 같습니다(위키에 반영 완)
```json
{
    "question": {
        "id": 46,
        "title": "List와 Tuple의 차이에 대해 설명해주세요.",
        "category": "CATEGORY_PYTHON"
    },
    "gpt": {
        "answerId": 119,
        "type": "TYPE_GPT",
        "account": null,
        "content": "List와 Tuple은 둘 다 파이썬에서 사용되는 데이터 구조입니다. 그러나 두 가지의 주요한 차이점이 있습니다.\n\n1. 가변성 (Mutability):\n- List는 가변적(mutable)입니다. 즉, List의 요소를 추가, 삭제, 수정할 수 있습니다.\n- Tuple은 불변적(immutable)입니다. 즉, Tuple의 요소를 변경할 수 없습니다. 한 번 생성된 Tuple은 수정할 수 없습니다.\n\n2. 표기법 (Syntax):\n- List는 대괄호([])로 둘러싸여 있습니다. 예를 들어, [1, 2, 3]은 List입니다.\n- Tuple은 소괄호(())로 둘러싸여 있습니다. 예를 들어, (1, 2, 3)은 Tuple입니다.\n\n이러한 차이점으로 인해 List는 동적인 데이터를 저장하고 관리하는 데 사용되는 반면, Tuple은 불변성과 구조적인 데이터를 저장하는 데 사용됩니다. List는 요소를 추가, 삭제, 수정할 수 있기 때문에 데이터의 변경이 필요한 경우에 유용합니다. Tuple은 변경이 필요하지 않은 데이터를 저장하는 데 사용되며, 일반적으로 함수의 반환 값이나 여러 값을 그룹화하는 데 사용됩니다. 또한 Tuple은 List보다 메모리를 더 적게 사용하고, 요소에 접근하는 속도가 더 빠릅니다.",
        "heartCount": null,
        "createdAt": null,
        "modifiedAt": null,
        "isHearted": null,
        "isMine": null
    },
    "answers": [
        {
            "answerId": 2,
            "type": "TYPE_ANSWER",
            "account": {
                "name": "test",
                "email": "test@gmail.com"
            },
            "content": "입력",
            "heartCount": 0,
            "createdAt": "2023-09-03T12:32:34",
            "modifiedAt": "2023-09-03T12:32:34",
            "isHearted": false,
            "isMine": false
        }
    ]
}
```

3. gpt 응답을 answer 테이블에서 조회해 객체 리스트로 가져왔을 때, 다른 응답보다 더 빠르게 처리가 될 수 있도록 repository 메서드를 수정하였습니다(DomainService == impl이므로 해당 부분은 수정 불필요)
```
List<Answer> findAllByQuestionIdOrderByTypeDesc(Long questionId);
```
- 미세하지만 100ms정도 조회 속도가 빨라졌습니다
- 일반 응답의 개수가 늘어나면 더 유의미하게 효과를 낼 것으로 보임